### PR TITLE
Fix for wireless adaptor

### DIFF
--- a/bypass.py
+++ b/bypass.py
@@ -233,7 +233,7 @@ print("\n[*] Found the below IPv4 addresses")
 tmpIPv4List=[]
 tmpIPTargetList=convertCIDR(targetIP)
 
-cmd="/usr/sbin/arp-scan "+targetIP
+cmd="/usr/sbin/arp-scan -I "+interfaceNo+" "+targetIP
 
 tmpResults=runCommand(cmd)
 tmpList1=tmpResults.split(b"\n")


### PR DESCRIPTION
The interface value was not passed to the arp-scan command. Updated code to include that.